### PR TITLE
chore: enable eslint-react plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,27 +1,19 @@
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import eslintReact from "@eslint-react/eslint-plugin";
+import typescriptEslint from "typescript-eslint";
 import globals from "globals";
-import tsParser from "@typescript-eslint/parser";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import { defineConfig } from "eslint/config";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
-});
-
-export default [...compat.extends(
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-), {
-    plugins: {
-        "@typescript-eslint": typescriptEslint,
-    },
-
+export default defineConfig({
+    files: [
+        "**/*.ts",
+        "**/*.tsx"
+    ],
+    extends: [
+        js.configs.recommended,
+        typescriptEslint.configs.recommended,
+        eslintReact.configs["recommended-typescript"],
+    ],
     languageOptions: {
         globals: {
             ...globals.browser,
@@ -39,8 +31,8 @@ export default [...compat.extends(
             mount: "readonly",
         },
 
-        parser: tsParser,
-        ecmaVersion: 5,
+        parser: typescriptEslint.parser,
+        ecmaVersion: 6,
         sourceType: "commonjs",
 
         parserOptions: {
@@ -48,7 +40,7 @@ export default [...compat.extends(
             jsx: true,
             js: true,
             useJSXTextNode: true,
-            project: "./tsconfig.json"
+            projectService: true,
         },
     },
 
@@ -70,22 +62,4 @@ export default [...compat.extends(
         "import/extensions": "off",
         "react/prop-types": "off",
     },
-}, ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-    ...config,
-    files: ["src/**/*.ts", "src/**/*.tsx"],
-})), {
-    files: ["src/**/*.ts", "src/**/*.tsx"],
-
-    plugins: {
-        "@typescript-eslint": typescriptEslint,
-    },
-
-    languageOptions: {
-        parser: tsParser,
-    },
-
-    rules: {
-        "react/prop-types": "off",
-        "@typescript-eslint/no-unused-vars": "error",
-    },
-}];
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "@patternfly/react-core": "6.4.3",
         "@patternfly/react-icons": "6.4.0",
         "@patternfly/react-styles": "6.4.0",
-        "react": "18",
-        "react-dom": "18"
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "3.3.5",
+        "@eslint-react/eslint-plugin": "5.7.1",
         "@eslint/js": "10.0.1",
         "@patternfly/react-charts": "8.4.1",
         "@testing-library/jest-dom": "6.9.1",
@@ -24,8 +24,6 @@
         "@testing-library/user-event": "14.6.1",
         "@types/jest": "30.0.0",
         "@types/react-router-dom": "5.3.3",
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
         "css-minimizer-webpack-plugin": "8.0.0",
@@ -56,6 +54,7 @@
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "tslib": "2.8.1",
         "typescript": "6.0.3",
+        "typescript-eslint": "8.59.1",
         "url-loader": "4.1.1",
         "victory": "37.3.6",
         "webpack": "5.106.2",
@@ -820,6 +819,156 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint-react/ast": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.7.1.tgz",
+      "integrity": "sha512-1j6jWWzwIrD61gEVb+llxp7hIW6mua6Mi0S5IrHlWhvbfM3mnQStfPgqddf4+FJbFXXQZyIR13ecZewSA/6ADw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/typescript-estree": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "string-ts": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/core": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.7.1.tgz",
+      "integrity": "sha512-wD/WHV8SUsPhsS8r8DEh041t43NsIzyI9llVLERcOcRyxamnEixzlkHlczy1QvymJeZyF36LXBw1alfuaZvBCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/jsx": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/eslint": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.7.1.tgz",
+      "integrity": "sha512-Gc3GfXTBBXYTSkkBa41XyXj5dK7v4VWdkT60xIgRS+0PogxA6X1JNl+oGZgSIH5lxdLUnRYSYlTy+NDbs9dFPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.59.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/eslint-plugin": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.7.1.tgz",
+      "integrity": "sha512-nJZp16zKGqBD0T4h2sVzCwke1jQsoGDDO1rih9STEUTADzximJ95cobrwT8+2Tu1a41AMAJ8MwBW1yWtfvVTZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/shared": "5.7.1",
+        "eslint-plugin-react-dom": "5.7.1",
+        "eslint-plugin-react-jsx": "5.7.1",
+        "eslint-plugin-react-naming-convention": "5.7.1",
+        "eslint-plugin-react-rsc": "5.7.1",
+        "eslint-plugin-react-web-api": "5.7.1",
+        "eslint-plugin-react-x": "5.7.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/jsx": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.7.1.tgz",
+      "integrity": "sha512-IxgVUuWTT2LdzkcXqmrewE4rkyiHom/8MqaW1HqhjamO6GfXXtouJdO2VIQ57w7xekbUG+bFEpJiGgSpTi+O3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/shared": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.7.1.tgz",
+      "integrity": "sha512-rdG2EWDtXB4jt8XgIByoWCUFeiPcimNBurhZuaOIEMpITfBoNaMtcr9cesZvrWvRcn8ElWri1jFIBQ5HydCxmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eslint": "5.7.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0",
+        "zod": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/var": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.7.1.tgz",
+      "integrity": "sha512-ZkgBgHa2v28iXVBeYnZ5g1WlZOsak06QLvfueiATzX53PkRye0//I8tZ5/rStb+IUFX7kTbXX0i8fh7jG7a3Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
@@ -898,67 +1047,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -3827,13 +3915,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -4020,6 +4101,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/birecord": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.1.tgz",
+      "integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -4550,6 +4638,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -5770,6 +5865,154 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-dom": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.7.1.tgz",
+      "integrity": "sha512-JUhW+jl/VyUw7fipXZHGG3AVZDNVG3lAXoewjKBaR6va/fnR8gG6iQY+R0boTF2f37C06vyPpnld9SOW2TV/8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/jsx": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "compare-versions": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-jsx": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.7.1.tgz",
+      "integrity": "sha512-pIDQQU5QZXLsaAShv7J2yVBpC9KAMQmOyBIEAPzDkOShVvH8p4Jyy/xQbvoTUE6UaOkpzsHRmOaTISLtdulmMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/core": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/jsx": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-naming-convention": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.7.1.tgz",
+      "integrity": "sha512-kmWTEgTyaCCmtpG0OvDzhQOCawSxLphX6Hs1cAskRFn2DO9So8JjHUX+/Q0D8MzR5rX6WL5jBu+I2AgdLXcpvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/core": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-rsc": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.7.1.tgz",
+      "integrity": "sha512-+NFJNT3s671jWokW5JdFrSjRoAd2BFO9TEQ360mfnor8nlJOoKUkrcygyij19s5Gy87QNu3DZ52mYEcErqnbnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/core": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-web-api": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.7.1.tgz",
+      "integrity": "sha512-j4/08Q6VM/+ppEEf1CWYn2XQ2FcSMrRHsnmOdzW0QWDR6VHuo7vuxY9uDP97A/c3fPMB7xNFuOyT+WE1BgsY/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/core": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "birecord": "^0.1.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-x": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.7.1.tgz",
+      "integrity": "sha512-XskzY5TH6asFkAIqmUXXjrxJjJS74YIAm6Q1fIC835gOkPlPOPOLNG1Sy9eS4uJ1fFhGnZ5jzlRFL8WgdU9LOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.1",
+        "@eslint-react/core": "5.7.1",
+        "@eslint-react/eslint": "5.7.1",
+        "@eslint-react/jsx": "5.7.1",
+        "@eslint-react/shared": "5.7.1",
+        "@eslint-react/var": "5.7.1",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/type-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/typescript-estree": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "compare-versions": "^6.1.1",
+        "string-ts": "^2.3.1",
+        "ts-api-utils": "^2.5.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5790,19 +6033,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/balanced-match": {
@@ -5904,24 +6134,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -7218,31 +7430,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -8797,19 +8984,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsdom": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
@@ -9753,18 +9927,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse-json": {
@@ -10797,12 +10959,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10819,15 +10979,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-dropzone": {
@@ -11238,12 +11398,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -11828,6 +11986,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/string-ts": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
+      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -12698,6 +12863,13 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -12821,6 +12993,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {
@@ -14175,6 +14371,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "3.3.5",
+    "@eslint-react/eslint-plugin": "5.7.1",
     "@eslint/js": "10.0.1",
     "@patternfly/react-charts": "8.4.1",
     "@testing-library/jest-dom": "6.9.1",
@@ -33,8 +33,6 @@
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "30.0.0",
     "@types/react-router-dom": "5.3.3",
-    "@typescript-eslint/eslint-plugin": "8.59.1",
-    "@typescript-eslint/parser": "8.59.1",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
     "css-minimizer-webpack-plugin": "8.0.0",
@@ -65,6 +63,7 @@
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "tslib": "2.8.1",
     "typescript": "6.0.3",
+    "typescript-eslint": "8.59.1",
     "url-loader": "4.1.1",
     "victory": "37.3.6",
     "webpack": "5.106.2",
@@ -77,7 +76,7 @@
     "@patternfly/react-core": "6.4.3",
     "@patternfly/react-icons": "6.4.0",
     "@patternfly/react-styles": "6.4.0",
-    "react": "18",
-    "react-dom": "18"
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   }
 }

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -11,17 +11,17 @@ import { useNavigate } from 'react-router-dom';
 
 const BASE_PATH = process.env.BASE_PATH || '/';
 
-const NotFound: React.FunctionComponent = () => {
-  function GoHomeBtn() {
-    const navigate = useNavigate();
-    function handleClick() {
-      navigate(BASE_PATH);
-    }
-    return (
-      <Button onClick={handleClick}>Take me home</Button>
-    );
+const GoHomeBtn: React.FunctionComponent = () => {
+  const navigate = useNavigate();
+  function handleClick() {
+    navigate(BASE_PATH);
   }
+  return (
+    <Button onClick={handleClick}>Take me home</Button>
+  );
+}
 
+const NotFound: React.FunctionComponent = () => {
   return (
     <PageSection hasBodyWrapper={false}>
     <EmptyState headingLevel="h1" icon={ExclamationTriangleIcon} titleText="404 Page not found" variant="full">

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -99,8 +99,8 @@ const flattenedRoutes: IAppRoute[] = routes.reduce(
 
 const AppRoutes = (): React.ReactElement => (
   <Routes>
-    {flattenedRoutes.map(({ path, element }, idx) => (
-      <Route path={path} element={element} key={idx} />
+    {flattenedRoutes.map(({ path, element }) => (
+      <Route path={path} element={element} key={path} />
     ))}
     <Route element={<NotFound />} />
   </Routes>

--- a/src/test/__snapshots__/app.test.tsx.snap
+++ b/src/test/__snapshots__/app.test.tsx.snap
@@ -150,7 +150,6 @@ exports[`App tests should render default App component 1`] = `
                 aria-labelledby="Trip Length-1"
                 class="pf-v6-c-nav__subnav"
                 hidden=""
-                inert=""
               >
                 <ul
                   class="pf-v6-c-nav__list"


### PR DESCRIPTION
This is step 4 of 4 steps to replace eslint-plugin-react and eslint-plugin-react-hooks with eslint-react/eslint-plugin and update typescript to version 6.0.x.

Step 1 was #455
Step 2 was #456
Step 3 was #436